### PR TITLE
Add cocartesian structure on kleisli categories

### DIFF
--- a/src/main/scala/functors.scala
+++ b/src/main/scala/functors.scala
@@ -46,9 +46,9 @@ final case class FunctorSyntax[F0 <: AnyFunctor](val f: F0) extends AnyVal {
     FunctorComposition[F0,G0](f,g)
 
   def id[
-    F00 >: F0 <: F0 { type Source = C; type Target = D },
-    C   >: F0#Source <: F0#Source,
-    D   >: F0#Target <: F0#Target
+    F00 >: F0         <: F0 { type Source = C; type Target = D },
+    C   >: F0#Source  <: F0#Source,
+    D   >: F0#Target  <: F0#Target
   ]
   : IdentityNaturalTransformation[C, F00, D] =
     IdentityNaturalTransformation(f: F00)

--- a/src/main/scala/kleisli.scala
+++ b/src/main/scala/kleisli.scala
@@ -15,7 +15,7 @@ trait AnyKleisliCategory extends AnyCategory { kleisli =>
 
   type Objects = Cat#Objects
 
-  type C[X <: Objects, Y <: Objects] = Cat#C[X, Monad#F[Y]]
+  type C[X <: Objects, Y <: Objects] = Cat#C[X, Functor#F[Y]]
 
   final def compose[X <: Objects, Y <: Objects, Z <: Objects]: (C[Y,Z], C[X,Y]) => C[X,Z] = (g,f) => {
 
@@ -31,6 +31,14 @@ trait AnyKleisliCategory extends AnyCategory { kleisli =>
 }
 
 case object AnyKleisliCategory {
+
+  type is[KC <: AnyKleisliCategory] = KC {
+    type Cat = KC#Cat
+    type Functor = KC#Functor
+    type Monad = KC#Monad
+  }
+
+  def is[KC <: AnyKleisliCategory](kc: KC): is[KC] = kc.asInstanceOf[is[KC]]
 
   implicit final class KleisliCategorySyntax[KlC <: AnyKleisliCategory](val klC: KlC) extends AnyVal {
 

--- a/src/main/scala/kleisli.scala
+++ b/src/main/scala/kleisli.scala
@@ -43,30 +43,39 @@ case object AnyKleisliCategory {
   implicit final class KleisliCategorySyntax[KlC <: AnyKleisliCategory](val klC: KlC) extends AnyVal {
 
     def freeF[
-      KlC0 >: KlC           <: KlC { type Cat = C0; type Functor = F0; type Monad = M0 },
-      C0    >: KlC#Cat      <: AnyCategory,
-      F0    >: KlC#Functor  <: AnyFunctor { type Source = C0; type Target = C0 },
-      M0    >: KlC#Monad    <: AnyMonad { type On = C0; type Functor = F0 }
-
+      KlC0  >: KlC          <: KlC          { type Cat = C0; type Functor = F0; type Monad = M0 },
+      C0    >: KlC#Cat      <: KlC#Cat,
+      F0    >: KlC#Functor  <: KlC#Functor  { type Source = C0; type Target = C0 },
+      M0    >: KlC#Monad    <: KlC#Monad    { type On = C0; type Functor = F0 }
     ]
     : KleisliFunctor[C0,F0,M0,KlC0] =
       KleisliFunctor(klC: KlC0)
 
     def forgetfulF[
-      KlC0 >: KlC           <: KlC { type Cat = C0; type Functor = F0; type Monad = M0 },
-      C0    >: KlC#Cat      <: AnyCategory,
-      F0    >: KlC#Functor  <: AnyFunctor { type Source = C0; type Target = C0 },
-      M0    >: KlC#Monad    <: AnyMonad { type On = C0; type Functor = F0 }
+      KlC0  >: KlC          <: KlC          { type Cat = C0; type Functor = F0; type Monad = M0 },
+      C0    >: KlC#Cat      <: KlC#Cat,
+      F0    >: KlC#Functor  <: KlC#Functor  { type Source = C0; type Target = C0 },
+      M0    >: KlC#Monad    <: KlC#Monad    { type On = C0; type Functor = F0 }
     ]
     : KleisliForget[C0,F0,M0,KlC0] =
       KleisliForget(klC: KlC0)
+
+    def coproductsFrom[
+      KlC0  >: KlC          <: KlC          { type Cat = C0; type Functor = F0; type Monad = M0 },
+      C0    >: KlC#Cat      <: KlC#Cat,
+      F0    >: KlC#Functor  <: KlC#Functor  { type Source = C0; type Target = C0 },
+      M0    >: KlC#Monad    <: KlC#Monad    { type On = C0; type Functor = F0 },
+      Coprd                 <: AnyCocartesianMonoidalStructure { type On = C0 }
+    ](coprd: Coprd)
+    : KleisliCoproductStructure[C0,Coprd,F0,M0,KlC0] =
+      KleisliCoproductStructure(klC: KlC0, coprd)
   }
 }
 
 case class KleisliCategory[
-  On0 <: AnyCategory,
-  Functor0 <: AnyFunctor { type Source = On0; type Target = On0 },
-  Monad0 <: AnyMonad { type On = On0; type Functor = Functor0 }
+  On0       <: AnyCategory,
+  Functor0  <: AnyFunctor { type Source = On0; type Target = On0 },
+  Monad0    <: AnyMonad   { type On = On0; type Functor = Functor0 }
 ]
 (val monad: Monad0) extends AnyKleisliCategory {
 
@@ -106,9 +115,9 @@ trait AnyKleisliFunctor extends AnyFunctor { kleisliF =>
 
 case class KleisliFunctor[
   On0 <: AnyCategory,
-  F0 <: AnyFunctor { type Source = On0; type Target = On0 },
-  M0 <: AnyMonad { type On = On0; type Functor = F0 },
-  KC <: AnyKleisliCategory { type Cat = On0; type Monad = M0; type Functor = F0 }
+  F0 <: AnyFunctor          { type Source = On0; type Target = On0 },
+  M0 <: AnyMonad            { type On = On0; type Functor = F0 },
+  KC <: AnyKleisliCategory  { type Cat = On0; type Monad = M0; type Functor = F0 }
 ](val target: KC) extends AnyKleisliFunctor {
 
   type On = On0

--- a/src/main/scala/kleisliCoproducts.scala
+++ b/src/main/scala/kleisliCoproducts.scala
@@ -4,15 +4,19 @@ trait AnyKleisliCoproductStructure extends AnyCocartesianMonoidalStructure { kle
 
   type BaseCocartesian <: AnyCocartesianMonoidalStructure
   val baseCocartesian: BaseCocartesian
+
   type On <: AnyKleisliCategory {
-    type Cat = BaseCocartesian#On
-    type Objects = BaseCocartesian#On#Objects
-    type Functor = kleisliSums.Functor
-    type Monad = kleisliSums.Monad
+    type Cat      = BaseCocartesian#On
+    type Functor  = kleisliSums.Functor
+    type Monad    = kleisliSums.Monad
   }
 
   type Functor <: BaseCocartesian#On ⟶ BaseCocartesian#On
-  type Monad <: AnyMonad { type Functor = kleisliSums.Functor; type On = BaseCocartesian#On }
+
+  type Monad <: AnyMonad {
+    type On       = BaseCocartesian#On
+    type Functor  = kleisliSums.Functor
+  }
 
   lazy val Free = on.freeF
   lazy val trueBase = AnyCocartesianMonoidalStructure.is(baseCocartesian)
@@ -20,37 +24,39 @@ trait AnyKleisliCoproductStructure extends AnyCocartesianMonoidalStructure { kle
   type ⊗[A <: On#Objects, B <: On#Objects] = BaseCocartesian# ⊗[A,B]
   type I = BaseCocartesian#I
 
-  override def left[A <: On#Objects, B <: On#Objects]: BaseCocartesian#On#C[A, Functor#F[A + B]] =
+  def left[A <: On#Objects, B <: On#Objects]: BaseCocartesian#On#C[A, Functor#F[A + B]] =
     Free(trueBase.left)
 
-  override def right[A <: On#Objects, B <: On#Objects]: BaseCocartesian#On#C[B, Functor#F[A + B]] =
+  def right[A <: On#Objects, B <: On#Objects]: BaseCocartesian#On#C[B, Functor#F[A + B]] =
     Free(trueBase.right)
 
-  override def nothing[A <: On#Objects]: BaseCocartesian#On#C[I, Functor#F[A]] =
+  def nothing[A <: On#Objects]: BaseCocartesian#On#C[I, Functor#F[A]] =
     Free(trueBase.nothing)
 
-  override def univ[A <: On#Objects, B <: On#Objects, X <: On#Objects]
+  def univ[A <: On#Objects, B <: On#Objects, X <: On#Objects]
   : ( BaseCocartesian#On#C[A, Functor#F[X]], BaseCocartesian#On#C[B, Functor#F[X]] ) =>
     BaseCocartesian#On#C[(A + B), Functor#F[X]] =
     (a,b) => trueBase.univ(a, b)
+
+  def assoc_left[A <: On#Objects, B <: On#Objects, C <: On#Objects]: BaseCocartesian#On#C[ A ⊗ (B ⊗ C), Functor#F[(A ⊗ B) ⊗ C] ] =
+    Free(trueBase.assoc_left)
+
+  def assoc_right[A <: On#Objects, B <: On#Objects, C <: On#Objects]: BaseCocartesian#On#C[ (A ⊗ B) ⊗ C, Functor#F[A ⊗ (B ⊗ C)] ] =
+    Free(trueBase.assoc_right)
 }
 
 case class KleisliCoproductStructure[
   On0 <: AnyCategory,
   BaseCocartesian0 <: AnyCocartesianMonoidalStructure { type On = On0 },
   Functor0 <: AnyFunctor { type Source = On0; type Target = On0 },
-  Monad0 <: AnyMonad { type On = On0; type Functor = Functor0 }
-](val monad: Monad0, val baseCocartesian: BaseCocartesian0) extends AnyKleisliCoproductStructure {
+  Monad0 <: AnyMonad { type On = On0; type Functor = Functor0 },
+  KlC0 <: AnyKleisliCategory { type Cat = On0; type Functor = Functor0; type Monad = Monad0 }
+]
+(val on: KlC0, val baseCocartesian: BaseCocartesian0) extends AnyKleisliCoproductStructure {
 
-  type BaseCocartesian = BaseCocartesian0
-  type Functor = Functor0
-  type Monad = Monad0
-  type On = KleisliCategory[On0,Functor0,Monad0]
-  lazy val on = KleisliCategory[On0,Functor0,Monad0](monad)
+  type BaseCocartesian  = BaseCocartesian0
+  type Functor          = Functor0
+  type Monad            = Monad0
 
-  // TODO clean this
-  def assoc_left[A <: On0#Objects, B <: On0#Objects, C <: On0#Objects]: On0#C[BaseCocartesian0# ⊗[A,BaseCocartesian0# ⊗[B,C]],Functor0#F[BaseCocartesian0# ⊗[BaseCocartesian0# ⊗[A,B],C]]] = ???
-
-  def assoc_right[A <: On0#Objects, B <: On0#Objects, C <: On0#Objects]: On0#C[BaseCocartesian0# ⊗[BaseCocartesian0# ⊗[A,B],C],Functor0#F[BaseCocartesian0# ⊗[A,BaseCocartesian0# ⊗[B,C]]]] = ???
-
+  type On = KlC0
 }

--- a/src/main/scala/kleisliCoproducts.scala
+++ b/src/main/scala/kleisliCoproducts.scala
@@ -1,0 +1,56 @@
+package ohnosequences.stuff
+
+trait AnyKleisliCoproductStructure extends AnyCocartesianMonoidalStructure { kleisliSums =>
+
+  type BaseCocartesian <: AnyCocartesianMonoidalStructure
+  val baseCocartesian: BaseCocartesian
+  type On <: AnyKleisliCategory {
+    type Cat = BaseCocartesian#On
+    type Objects = BaseCocartesian#On#Objects
+    type Functor = kleisliSums.Functor
+    type Monad = kleisliSums.Monad
+  }
+
+  type Functor <: BaseCocartesian#On ⟶ BaseCocartesian#On
+  type Monad <: AnyMonad { type Functor = kleisliSums.Functor; type On = BaseCocartesian#On }
+
+  lazy val Free = on.freeF
+  lazy val trueBase = AnyCocartesianMonoidalStructure.is(baseCocartesian)
+
+  type ⊗[A <: On#Objects, B <: On#Objects] = BaseCocartesian# ⊗[A,B]
+  type I = BaseCocartesian#I
+
+  override def left[A <: On#Objects, B <: On#Objects]: BaseCocartesian#On#C[A, Functor#F[A + B]] =
+    Free(trueBase.left)
+
+  override def right[A <: On#Objects, B <: On#Objects]: BaseCocartesian#On#C[B, Functor#F[A + B]] =
+    Free(trueBase.right)
+
+  override def nothing[A <: On#Objects]: BaseCocartesian#On#C[I, Functor#F[A]] =
+    Free(trueBase.nothing)
+
+  override def univ[A <: On#Objects, B <: On#Objects, X <: On#Objects]
+  : ( BaseCocartesian#On#C[A, Functor#F[X]], BaseCocartesian#On#C[B, Functor#F[X]] ) =>
+    BaseCocartesian#On#C[(A + B), Functor#F[X]] =
+    (a,b) => trueBase.univ(a, b)
+}
+
+case class KleisliCoproductStructure[
+  On0 <: AnyCategory,
+  BaseCocartesian0 <: AnyCocartesianMonoidalStructure { type On = On0 },
+  Functor0 <: AnyFunctor { type Source = On0; type Target = On0 },
+  Monad0 <: AnyMonad { type On = On0; type Functor = Functor0 }
+](val monad: Monad0, val baseCocartesian: BaseCocartesian0) extends AnyKleisliCoproductStructure {
+
+  type BaseCocartesian = BaseCocartesian0
+  type Functor = Functor0
+  type Monad = Monad0
+  type On = KleisliCategory[On0,Functor0,Monad0]
+  lazy val on = KleisliCategory[On0,Functor0,Monad0](monad)
+
+  // TODO clean this
+  def assoc_left[A <: On0#Objects, B <: On0#Objects, C <: On0#Objects]: On0#C[BaseCocartesian0# ⊗[A,BaseCocartesian0# ⊗[B,C]],Functor0#F[BaseCocartesian0# ⊗[BaseCocartesian0# ⊗[A,B],C]]] = ???
+
+  def assoc_right[A <: On0#Objects, B <: On0#Objects, C <: On0#Objects]: On0#C[BaseCocartesian0# ⊗[BaseCocartesian0# ⊗[A,B],C],Functor0#F[BaseCocartesian0# ⊗[A,BaseCocartesian0# ⊗[B,C]]]] = ???
+
+}

--- a/src/main/scala/monads.scala
+++ b/src/main/scala/monads.scala
@@ -71,16 +71,9 @@ case object AnyMonad {
       M0 >: M         <: M { type On = C; type Functor = F0 },
       F0 >: M#Functor <: M#Functor { type Source = C; type Target = C },
       C  >: M#On      <: M#On
-    ]: KleisliCategory[C, F0, M0] = KleisliCategory(m: M0)
-
-    def coproductsFrom[
-      M0 >: M         <: M { type On = C; type Functor = F0 },
-      F0 >: M#Functor <: M#Functor { type Source = C; type Target = C },
-      C  >: M#On      <: M#On,
-      Coprd <: AnyCocartesianMonoidalStructure { type On = C }
     ]
-    (coprd: Coprd): KleisliCoproductStructure[C,Coprd,F0,M0] =
-      KleisliCoproductStructure(m: M0, coprd)
+    : KleisliCategory[C, F0, M0] = 
+      KleisliCategory(m: M0)
   }
 }
 

--- a/src/main/scala/monads.scala
+++ b/src/main/scala/monads.scala
@@ -72,6 +72,15 @@ case object AnyMonad {
       F0 >: M#Functor <: M#Functor { type Source = C; type Target = C },
       C  >: M#On      <: M#On
     ]: KleisliCategory[C, F0, M0] = KleisliCategory(m: M0)
+
+    def coproductsFrom[
+      M0 >: M         <: M { type On = C; type Functor = F0 },
+      F0 >: M#Functor <: M#Functor { type Source = C; type Target = C },
+      C  >: M#On      <: M#On,
+      Coprd <: AnyCocartesianMonoidalStructure { type On = C }
+    ]
+    (coprd: Coprd): KleisliCoproductStructure[C,Coprd,F0,M0] =
+      KleisliCoproductStructure(m: M0, coprd)
   }
 }
 

--- a/src/main/scala/monoidalCategories.scala
+++ b/src/main/scala/monoidalCategories.scala
@@ -78,7 +78,21 @@ trait AnyCocartesianMonoidalStructure extends AnyMonoidalStructure {
 
   def univ_inv[A <: On#Objects, B <: On#Objects, X <: On#Objects]: On#C[ A + B, X ] => (On#C[A,X], On#C[B,X]) =
     { f => (left >=> f, right >=> f) }
+}
 
+case object AnyCocartesianMonoidalStructure {
+
+  type is[S <: AnyCocartesianMonoidalStructure] = S {
+
+    type On = S#On
+    type I = S#I
+
+    type ⊗[X <: On#Objects, Y <: On#Objects] = S# ⊗[X,Y]
+    type ×[X <: On#Objects, Y <: On#Objects] = S# +[X,Y]
+  }
+
+  def is[MCat <: AnyCocartesianMonoidalStructure](mcat: MCat): is[MCat] =
+    mcat.asInstanceOf[is[MCat]]
 }
 
 trait AnyRigStructure { rig =>

--- a/src/test/scala/categories.scala
+++ b/src/test/scala/categories.scala
@@ -45,3 +45,75 @@ trait MealyCat extends AnyCategory {
     }
   }
 }
+
+case object Mealy extends MealyCat
+
+case object Scala extends AnyCategory {
+
+  type Objects = Any
+  type C[A,B] = A => B
+
+  def compose[X <: Objects, Y <: Objects, Z <: Objects]: (C[Y,Z], C[X,Y]) => C[X,Z] = (g,f) => f andThen g
+  def id[X <: Objects]: C[X,X] = { x: X => x }
+}
+
+
+case object ScalaSums extends AnyCocartesianMonoidalStructure {
+
+  type On     = Scala.type
+  val on: On  = Scala
+
+  type ⊗[X, Y] = X Either Y
+  type I = Nothing
+
+  def left  [A <: On#Objects, B <: On#Objects]: A => A + B =
+    a => Left(a)
+
+  def right [A <: On#Objects, B <: On#Objects]: B => A + B =
+    b => Right(b)
+
+  def nothing [A <: On#Objects]: Nothing => A =
+    { _ => ??? }
+
+  def univ[A <: On#Objects, B <: On#Objects, X <: On#Objects]: (A => X, B => X) => (A + B => X) =
+    (f,g) => { ab => ab.fold(f,g) }
+
+  def assoc_right[A, B, C]: (A + B) + C => A + (B + C) =
+    {
+      ab_c => ab_c match {
+
+        case Left(ab) => ab match {
+
+          case Left(a)  => Left(a)
+          case Right(b) => Right(Left(b))
+        }
+
+        case Right(c) => Right(Right(c))
+      }
+    }
+
+  def assoc_left[A, B, C]: A + (B + C) => (A + B) + C =
+    {
+      a_bc => a_bc match {
+
+        case Left(a) => Left(Left(a))
+
+        case Right(bc) => bc match {
+
+          case Left(b)  => Left(Right(b))
+          case Right(c) => Right(c)
+        }
+      }
+    }
+}
+
+
+class MealyTests extends FunSuite {
+
+  test("identity monad") {
+
+    val idMonad     = IdentityMonad(Scala)
+    val idMonadKl   = idMonad kleisliCategory
+    val kleisliSums = idMonadKl coproductsFrom ScalaSums
+  }
+}


### PR DESCRIPTION
Kleisli categories always have coproducts when the base has, with the kleisli functor preserving them (it is a left adjoint)