### PR TITLE
monoidal functors need to leave source and target free

### DIFF
--- a/src/main/scala/monoidalFunctors.scala
+++ b/src/main/scala/monoidalFunctors.scala
@@ -31,9 +31,9 @@ trait AnyLaxMonoidalFunctor {
 
 abstract class LaxMonoidalFunctor[
   SCat <: AnyCategory,
-  SM <: AnyCoproducts { type On = SCat },
+  SM <: AnyMonoidalCategory { type On = SCat },
   Functor0 <: AnyFunctor { type Source = SCat; type Target = TCat },
-  TM <: AnyCoproducts { type On = TCat },
+  TM <: AnyMonoidalCategory { type On = TCat },
   TCat <: AnyCategory
 ]
 (
@@ -52,35 +52,39 @@ extends AnyLaxMonoidalFunctor {
 
 trait AnyColaxMonoidalFunctor {
 
-  type TargetMonoidalCategory <: AnyMonoidalCategory
+  type SourceCategory <: AnyCategory
+  lazy val sourceCategory: SourceCategory = sourceMonoidalCategory.on
+
+  type SourceMonoidalCategory <: AnyMonoidalCategory { type On = SourceCategory }
   val sourceMonoidalCategory: SourceMonoidalCategory
-  type SourceMonoidalCategory <: AnyMonoidalCategory
+
+  type TargetCategory <: AnyCategory
+  lazy val targetCategory: TargetCategory = targetMonoidalCategory.on
+
+  type TargetMonoidalCategory <: AnyMonoidalCategory { type On = TargetCategory }
   val targetMonoidalCategory: TargetMonoidalCategory
 
   // NOTE notation
-  type □[X <: Source#Objects, Y <: Source#Objects] = SourceMonoidalCategory# ⊗[X,Y]
-  type ⋄[X <: Target#Objects, Y <: Target#Objects] = TargetMonoidalCategory# ⊗[X,Y]
-
-  type Source = SourceMonoidalCategory#On
-  lazy val source = sourceMonoidalCategory.on
-  type Target = TargetMonoidalCategory#On
-  lazy val target = targetMonoidalCategory.on
+  type □[X <: SourceCategory#Objects, Y <: SourceCategory#Objects] = SourceMonoidalCategory# ⊗[X,Y]
+  type ⋄[X <: TargetCategory#Objects, Y <: TargetCategory#Objects] = TargetMonoidalCategory# ⊗[X,Y]
 
   type Functor <: AnyFunctor {
-    type Source = SourceMonoidalCategory#On
-    type Target = TargetMonoidalCategory#On
+    type Source = SourceCategory
+    type Target = TargetCategory
   }
   val functor: Functor
 
-  def unzip[A <: Source#Objects, B <: Source#Objects]: Target#C[Functor#F[A □ B], Functor#F[A] ⋄ Functor#F[B]]
+  def unzip[A <: SourceCategory#Objects, B <: SourceCategory#Objects]: TargetCategory#C[Functor#F[A □ B], Functor#F[A] ⋄ Functor#F[B]]
 
-  def counit: Target#C[Functor#F[SourceMonoidalCategory#I], TargetMonoidalCategory#I]
+  def counit: TargetCategory#C[Functor#F[SourceMonoidalCategory#I], TargetMonoidalCategory#I]
 }
 
 abstract class ColaxMonoidalFunctor[
-  SM <: AnyMonoidalCategory,
-  Functor0 <: AnyFunctor { type Source = SM#On; type Target = TM#On },
-  TM <: AnyMonoidalCategory
+  SCat <: AnyCategory,
+  SM <: AnyMonoidalCategory { type On = SCat },
+  Functor0 <: AnyFunctor { type Source = SCat; type Target = TCat },
+  TM <: AnyMonoidalCategory { type On = TCat },
+  TCat <: AnyCategory
 ]
 (
   val sourceMonoidalCategory: SM,
@@ -89,36 +93,37 @@ abstract class ColaxMonoidalFunctor[
 )
 extends AnyColaxMonoidalFunctor {
 
+  type SourceCategory         = SCat
   type SourceMonoidalCategory = SM
-  type Functor = Functor0
+  type Functor                = Functor0
   type TargetMonoidalCategory = TM
+  type TargetCategory         = TCat
 }
+
 
 /*
   A functor between cartesian monoidal categories is automatically colax monoidal. This construction only requires of the domain to be *affine* (a terminal unit), but we don't want to make this overly complex. See for example the [nLab](https://ncatlab.org/nlab/show/semicartesian+monoidal+category).
 */
 case class ColaxCartesianMonoidalFunctor[
-  SM <: AnyProducts,
-  Functor0 <: AnyFunctor { type Source = SM#On; type Target = TM#On },
-  TM <: AnyProducts
+  SCat <: AnyCategory,
+  SM <: AnyProducts { type On = SCat },
+  Functor0 <: AnyFunctor { type Source = SCat; type Target = TCat },
+  TM <: AnyProducts { type On = TCat },
+  TCat <: AnyCategory
 ](
-  val sourceMonoidalCategory: SM,
-  val functor: Functor0,
-  val targetMonoidalCategory: TM
+  val sourceMonoidalCategory0: SM,
+  val functor0: Functor0,
+  val targetMonoidalCategory0: TM
 )
-extends AnyColaxMonoidalFunctor {
+extends ColaxMonoidalFunctor[SCat,SM,Functor0,TM,TCat](sourceMonoidalCategory0, functor0, targetMonoidalCategory0) {
 
-  type SourceMonoidalCategory = SM
-  type Functor = Functor0
-  type TargetMonoidalCategory = TM
-
-  def unzip[A <: Source#Objects, B <: Source#Objects]: Target#C[Functor#F[A □ B], Functor#F[A] ⋄ Functor#F[B]] =
+  def unzip[A <: SourceCategory#Objects, B <: SourceCategory#Objects]: TargetCategory#C[Functor#F[A □ B], Functor#F[A] ⋄ Functor#F[B]] =
     AnyMonoidalCategory.is(targetMonoidalCategory).univ(
       AnyFunctor.is(functor)(AnyMonoidalCategory.is(sourceMonoidalCategory).left[A,B]),
       AnyFunctor.is(functor)(AnyMonoidalCategory.is(sourceMonoidalCategory).right[A,B])
     )
 
-  def counit: Target#C[Functor#F[SourceMonoidalCategory#I], TargetMonoidalCategory#I] =
+  def counit: TargetCategory#C[Functor#F[SourceMonoidalCategory#I], TargetMonoidalCategory#I] =
     AnyMonoidalCategory.is(targetMonoidalCategory).erase
 }
 


### PR DESCRIPTION
Setting source and target to the underlying categories of the corresponding monoidal structures leads to issues, whose description is too long to fit here. Monoidal functors should instead have source and target free (with bound AnyCategory), and the monoidal structures be defined on them.