### PR TITLE
Review Functors

### DIFF
--- a/src/main/scala/stuff/functors.scala
+++ b/src/main/scala/stuff/functors.scala
@@ -18,14 +18,14 @@ abstract class Functor {
   def at[
       X <: Source#Objects,
       Y <: Source#Objects
-  ]: Category.is[Source]#C[X, Y] -> Target#C[F[X], F[Y]]
+  ]: Source#C[X, Y] -> Target#C[F[X], F[Y]]
 }
 
 object Functor {
 
   implicit final class FunctorSyntax[Fn <: Functor](val functor: inferIs[Fn]) {
 
-    def apply[X <: Fn#Source#Objects, Y <: Fn#Source#Objects](
+    def apply[X <: Fn#SourceObjects, Y <: Fn#SourceObjects](
         f: Fn#Source#C[X, Y]): Fn#Target#C[Fn#F[X], Fn#F[Y]] =
       functor.at[X, Y](f)
 
@@ -88,11 +88,11 @@ object Functor {
     type Target = G0#Target
     val target = second.target
 
-    type F[Z <: F0#Source#Objects] = G0#F[F0#F[Z]]
+    type F[Z <: F0#SourceObjects] = G0#F[F0#F[Z]]
 
     def at[
-        X <: Source#Objects,
-        Y <: Source#Objects
+        X <: SourceObjects,
+        Y <: SourceObjects
     ]: Source#C[X, Y] -> Target#C[F[X], F[Y]] =
       first.at >-> second.at
   }

--- a/src/main/scala/stuff/functors.scala
+++ b/src/main/scala/stuff/functors.scala
@@ -25,11 +25,15 @@ object Functor {
 
   implicit final class FunctorSyntax[Fn <: Functor](val functor: inferIs[Fn]) {
 
-    def apply[X <: Fn#SourceObjects, Y <: Fn#SourceObjects](
+    @inline final def apply[X <: Fn#SourceObjects, Y <: Fn#SourceObjects](
         f: Fn#Source#C[X, Y]): Fn#Target#C[Fn#F[X], Fn#F[Y]] =
       functor.at[X, Y](f)
 
-    def >->[Gn <: Functor { type Source = Fn#Target }](
+    @inline final def >->[Gn <: Functor { type Source = Fn#Target }](
+        other: inferIs[Gn]): is[Fn ∘ Gn] =
+      composition(functor and other)
+
+    @inline final def ∘[Gn <: Functor { type Source = Fn#Target }](
         other: inferIs[Gn]): is[Fn ∘ Gn] =
       composition(functor and other)
   }

--- a/src/main/scala/stuff/functors.scala
+++ b/src/main/scala/stuff/functors.scala
@@ -23,11 +23,15 @@ abstract class Functor {
 
 object Functor {
 
-  implicit final class FunctorSyntax[Fn <: Functor](val functor: is[Fn]) {
+  implicit final class FunctorSyntax[Fn <: Functor](val functor: inferIs[Fn]) {
 
     def apply[X <: Fn#Source#Objects, Y <: Fn#Source#Objects](
         f: Fn#Source#C[X, Y]): Fn#Target#C[Fn#F[X], Fn#F[Y]] =
       functor.at[X, Y](f)
+
+    def >->[Gn <: Functor { type Source = Fn#Target }](
+        other: inferIs[Gn]): is[Fn ∘ Gn] =
+      composition(functor and other)
   }
 
   type between[Src <: Category, Tgt <: Category] =
@@ -35,6 +39,9 @@ object Functor {
       type Source = Src
       type Target = Tgt
     }
+
+  // Let's hope https://github.com/scala/scala/pull/6140 makes this unnecessary
+  type inferIs[functor <: Functor] >: is[functor] <: is[functor]
 
   type is[functor <: Functor] =
     functor {

--- a/src/test/scala/functors/functorExamples.scala
+++ b/src/test/scala/functors/functorExamples.scala
@@ -8,12 +8,18 @@ import org.scalatest.FunSuite
 
 case object boh {
 
+  val Id =
+    Functor.identity at Scala
+
   val buh =
-    (Functor.identity at Scala) at {
+    Id at {
       λ { x: String =>
         s"hola ${x}!"
       }
     }
+
+  val IdTwice =
+    Id >-> Id
 }
 
 class FunctorsExamples extends FunSuite {

--- a/src/test/scala/functors/functorExamples.scala
+++ b/src/test/scala/functors/functorExamples.scala
@@ -20,6 +20,9 @@ case object boh {
 
   val IdTwice =
     Id >-> Id
+
+  val IdTwiceAgain =
+    Id ∘ Id
 }
 
 class FunctorsExamples extends FunSuite {


### PR DESCRIPTION
Similar to #56.

- [x] *can we add functor composition syntax?*
   **Yes**
- [x] *should the bound in `F[X <: Source#Objects]` be `F[Category.is[Source]#Objects]`? I think so*
    **No need to** We are using `functor#SourceObjects` instead
- [x] *it looks like `Functor.is[_]` should be left undefined `type is[Fnctr <: Functor] >: ... <: ...` if we want syntax for composition. Review this.* 
    **Solved** Added a weaker `inferIs[Fn <: Functor] >: is[Fn] <: is[Fn]` alias.